### PR TITLE
Fixed "Invalid api path." error on logout

### DIFF
--- a/src/Smalot/Magento/RemoteAdapter.php
+++ b/src/Smalot/Magento/RemoteAdapter.php
@@ -174,7 +174,7 @@ class RemoteAdapter implements RemoteAdapterInterface
     public function logout()
     {
         if (null !== $this->sessionId) {
-            $this->call(new Action('logout'), false);
+            $this->soapClient->endSession($this->sessionId);
             $this->sessionId = null;
 
             return true;


### PR DESCRIPTION
Magento was complaining because there was no resource/action matching "logout". Instead, I'm calling the API's endSession method. The error wasn't initially visible because $this->call had its second param (throwExceptions) set to false.
