### PR TITLE
Change bogus create call to __createAction call.

### DIFF
--- a/src/Smalot/Magento/Catalog/ProductAttributeSet.php
+++ b/src/Smalot/Magento/Catalog/ProductAttributeSet.php
@@ -38,7 +38,7 @@ class ProductAttributeSet extends MagentoModuleAbstract
      */
     public function attributeAdd($attributeId, $attributeSetId, $attributeGroupId = null, $sortOrder = null)
     {
-        return $this->create('product_attribute_set.attributeAdd', func_get_args());
+        return $this->__createAction('product_attribute_set.attributeAdd', func_get_args());
     }
 
     /**


### PR DESCRIPTION
I was running into an error message from Magento trying to add an attribute to an attribute set.

`SQLSTATE[21000]: Cardinality violation: 1241 Operand should contain 1 column(s)`

Finally I realized there was a bug in the client library.