### PR TITLE
Wrong method name for OrderShipment getInfo

### DIFF
--- a/src/Smalot/Magento/Order/OrderShipment.php
+++ b/src/Smalot/Magento/Order/OrderShipment.php
@@ -93,7 +93,7 @@ class OrderShipment extends MagentoModuleAbstract
      */
     public function getInfo($shipmentIncrementId)
     {
-        return $this->__createAction('salesOrderShipmentInfo', func_get_args());
+        return $this->__createAction('order_shipment.info', func_get_args());
     }
 
     /**


### PR DESCRIPTION
Method name of wrong API version for getting shipment info. V2 method name was used.
